### PR TITLE
Updated test

### DIFF
--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,30 +1,29 @@
 import { test, expect } from '@playwright/test';
 
 test('Change language', async ({ page }) => {
-  await page.goto('/nl/login/');
-  await page.getByLabel('Email').click();
-  await page.getByLabel('Email').fill('admin@sp');
-  await page.getByLabel('Password').click();
-  await page.getByLabel('Password').fill('password');
-  await page.getByRole('checkbox').check();
-  await page.getByRole('button', { name: 'Login' }).click();
 
-  // Expect url to contain the default language nl
-  expect(page.url()).toContain('/nl/');
-  await page.getByRole('button').nth(1).click();
+  await page.goto('http://localhost:3000/nl/login/');
+  await page.getByPlaceholder('Your email').click();
+  await page.getByPlaceholder('Your email').fill('student@sp.nl');
+  await page.getByPlaceholder('Your password').click();
+  await page.getByPlaceholder('Your password').fill('password');
+  await page.getByRole('button', { name: 'Log in' }).click();
+
+  // Wait a little
+  await page.waitForTimeout(3000);
+
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+  await page.locator('header').getByRole('button').nth(1).click();
   await page.getByText('English').click();
+  await expect(page.locator('#Competencies')).toContainText('Competencies');
+  await page.locator('header').getByRole('button').nth(1).click();
+  await page.getByText('Nederlands').click();
+  await expect(page.locator('#Competenties')).toContainText('Competenties');
+  await page.locator('header').getByRole('button').nth(1).click();
+  await page.getByText('Uitloggen').click();
 
   // Wait a little
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(3000);
 
-  // Expect url to contain the new language en
-  expect(page.url()).toContain('/en/');
-
-  await page.getByRole('button').nth(1).click();
-  await page.getByRole('menuitem', { name: 'nl Nederlands' }).click();
-
-  // Wait a little
-  await page.waitForTimeout(1000);
-
-  expect(page.url()).toContain('/nl/');
+  await expect(page.getByRole('button')).toContainText('Log in');
 });


### PR DESCRIPTION
This pull request includes significant updates to the test case for changing the language on the login page in `tests/index.spec.ts`. The changes improve the test's robustness and clarity by updating the selectors and expectations to be more specific and relevant.

Improvements to test case:

* Updated the URL to use `http://localhost:3000/nl/login/` instead of a relative path.
* Changed input field selectors from `getByLabel` to `getByPlaceholder` for better specificity.
* Updated the login button selector to use `getByRole` with the name 'Log in'.
* Added expectations to check for the visibility of the 'Dashboard' heading and the presence of specific text in the page content to verify language changes.
* Increased wait times from 1000ms to 3000ms to ensure adequate time for page transitions and content loading.