### PR TITLE
Updated little things

### DIFF
--- a/src/app/[locale]/(authenticated)/student/competencies/page.tsx
+++ b/src/app/[locale]/(authenticated)/student/competencies/page.tsx
@@ -55,7 +55,7 @@ const CompetenciesOverview = (props: { searchParams: Promise<SkillsQueryType> })
 
         <div className={cn("transition-all duration-500", isLoading ? "blur-md cursor-wait" : "blur-0")}>
             {!!competencies ?
-                <Pager pagerObject={competencies} renderItem={renderCompetencies} emptyMessage={t("noEntitiesFound", { entities: t("competencies").toLowerCase() })} wrapperClass="grid lg:grid-cols-2 xl:grid-cols-3 gap-8 items-start" />
+                <Pager pagerObject={competencies} renderItem={renderCompetencies} emptyMessage={t("noEntitiesFound", { entities: t("competencies").toLowerCase() })} wrapperClass="grid lg:grid-cols-2 xl:grid-cols-3 gap-8 items-stretch" />
                 :
                 <Skeletons amount={15} className="w-full h-28" />
             }

--- a/src/app/[locale]/(authenticated)/teacher/groups/[id]/page.tsx
+++ b/src/app/[locale]/(authenticated)/teacher/groups/[id]/page.tsx
@@ -40,7 +40,7 @@ const GroupsDetail = async (props: { params: Promise<{ id: number }> }) => {
         </div>
 
         <div className="">
-            <div className="flex flex-col sm:flex-row sm:justify-between items-center lg:justify-normal lg:gap-8 mb-4">
+            <div className="flex flex-row justify-between items-center lg:justify-normal lg:gap-8 mb-4">
                 {/* Title */}
                 <PageTitle className="mb-4">{group.name}</PageTitle>
 

--- a/src/app/[locale]/(authenticated)/teacher/skills/[id]/page.tsx
+++ b/src/app/[locale]/(authenticated)/teacher/skills/[id]/page.tsx
@@ -60,7 +60,7 @@ const SkillDetail = async (props: { params: Promise<{ id: number }> }) => {
         {/* Competency */}
         <div>
             <div className="font-bold mb-2">{t("competency")}</div>
-            {skill.competency && <Link href={`/student/competencies/${skill.competency.id}`}>
+            {skill.competency && <Link href={`/teacher/competencies`}>
                 <div className="bg-sidebar-accent px-4 py-1 rounded-full w-fit">{skill.competency.title}</div>
             </Link>}
         </div>
@@ -68,10 +68,10 @@ const SkillDetail = async (props: { params: Promise<{ id: number }> }) => {
         {/* Groups */}
         <div>
             <SectionTitle numberOfItems={skill.groups?.length}>{t("groups")}</SectionTitle>
-            <div className="grid lg:grid-cols-2 xl:grid-cols-3 gap-8 items-start">
-                {skill?.groups?.map((group) => <div key={group.id}>
+            <div className="grid lg:grid-cols-2 xl:grid-cols-3 gap-2 md:gap-4 items-stretch ">
+                {skill?.groups?.map((group) => <div key={group.id} className="border p-4 rounded-lg hover:bg-muted">
                     <Link href={`/teacher/groups/${group.id}`}>
-                        <span className="text-xl font-sans">{group.name}</span>
+                        <span className="text-xl font-semibold font-sans">{group.name}</span>
                         <p>{group.desc}</p>
                         <div className="flex items-center gap-2 mt-4">
                             <UsersIcon size={18} />

--- a/src/components/CompetenciesCard.tsx
+++ b/src/components/CompetenciesCard.tsx
@@ -19,7 +19,7 @@ export default function CompetenciesCard({ competency, mutate }: { competency: C
     })
 
     return (
-        <div className="flex flex-col border rounded-lg px-4 py-3">
+        <div className="relative flex flex-col border rounded-lg px-4 py-3 pb-12">
 
             {/* Title and description */}
             <div className="mb-4">
@@ -52,11 +52,13 @@ export default function CompetenciesCard({ competency, mutate }: { competency: C
                 </div>
             </div>
 
-            <Link href={`/student/competencies/${competency.id}`}>
-                <Button variant="outline" className="w-full">
-                    {t("view")}
-                </Button>
-            </Link>
+            <div className="absolute bottom-2 w-full">
+                <Link href={`/student/competencies/${competency.id}`}>
+                    <Button variant="outline" className="w-full">
+                        {t("view")}
+                    </Button>
+                </Link>
+            </div>
 
         </div>
     )

--- a/src/hooks/use-coaches.ts
+++ b/src/hooks/use-coaches.ts
@@ -4,7 +4,8 @@ import { UserType } from "@/types/auth"
 import useSWR from "swr"
 
 export const useCoaches = () => {
-    const url = `/api/student/teachers`
+    // Crazy number of coaches to prevent pagination in dropdowns
+    const url = `/api/student/teachers?per_page=500`
     return useSWR(url, () =>
         axiosInstance.get(url)
             .then((res: { data: { data: UserType[] } }) => {

--- a/src/hooks/use-compentencies.ts
+++ b/src/hooks/use-compentencies.ts
@@ -3,7 +3,8 @@ import { CompetencyType } from "@/types"
 import useSWR from "swr"
 
 export const useCompetencies = () => {
-    const url = "/api/competencies"
+    // Crazy number of competencies to prevent pagination in dropdowns
+    const url = "/api/competencies?per_page=500"
     return useSWR(url, () =>
         axiosInstance.get(url)
             .then((res: { data: { data: CompetencyType[] } }) => {

--- a/src/hooks/use-group-skills.ts
+++ b/src/hooks/use-group-skills.ts
@@ -3,7 +3,8 @@ import { SkillType } from "@/types"
 import useSWR from "swr"
 
 export const useGroupSkills = (id?: string) => {
-    const url = id ? `/api/student/groups/${id}/skills` : ``
+    // Crazy number of skills to prevent pagination in dropdowns
+    const url = id ? `/api/student/groups/${id}/skills?per_page=500` : ``
     return useSWR(url, () =>
         axiosInstance.get(url)
             .then((res: { data: { data: SkillType[] } }) => {

--- a/src/hooks/use-skills.ts
+++ b/src/hooks/use-skills.ts
@@ -3,7 +3,8 @@ import { SkillType } from "@/types"
 import useSWR from "swr"
 
 export const useSkills = () => {
-    const url = `/api/teacher/skills`
+    // Crazy number of skills to prevent pagination in dropdowns
+    const url = `/api/teacher/skills?per_page=500`
     return useSWR(url, () =>
         axiosInstance.get(url)
             .then((res: { data: { data: SkillType[] } }) => {

--- a/src/hooks/use-students.ts
+++ b/src/hooks/use-students.ts
@@ -4,7 +4,8 @@ import { UserType } from "@/types/auth"
 import useSWR from "swr"
 
 export const useStudents = () => {
-    const url = `/api/teacher/students`
+    // Crazy number of students to prevent pagination in dropdowns
+    const url = `/api/teacher/students?per_page=500`
     return useSWR(url, () =>
         axiosInstance.get(url)
             .then((res: { data: { data: UserType[] } }) => {

--- a/src/lib/queries/server/queries.ts
+++ b/src/lib/queries/server/queries.ts
@@ -8,7 +8,7 @@ import { getData } from "./data-fetching";
 
 export const getStudentSkill = async (id: number) => {
     try {
-        const { result } = await getData<SkillType>(`/api/student/skills/${id}?with=skill,createdBy`);
+        const { result } = await getData<SkillType>(`/api/student/skills/${id}`);
         return result
     }
     catch (error) {


### PR DESCRIPTION
This pull request includes several changes to the `src` directory, focusing on improving the layout and preventing pagination in dropdowns. The most important changes are grouped by theme below.

### Layout improvements:

* `src/app/[locale]/(authenticated)/student/competencies/page.tsx`: Modified the `Pager` component's `wrapperClass` to use `items-stretch` instead of `items-start` for better alignment. ([src/app/[locale]/(authenticated)/student/competencies/page.tsxL58-R58](diffhunk://#diff-b9d719c136959e8d6f3ab2ba8c4ba2cf220af6bf91ad85929d05855f8f1daa11L58-R58))
* `src/app/[locale]/(authenticated)/teacher/skills/[id]/page.tsx`: Changed the link for `skill.competency` to `/teacher/competencies` and updated the `groups` grid layout to use `items-stretch` and added styling to group items. ([src/app/[locale]/(authenticated)/teacher/skills/[id]/page.tsxL63-R74](diffhunk://#diff-d80d6c43343e61e606f984c7037ee0a6cdfa22f1702a2b71c8e39cd5a9d0db8cL63-R74))
* [`src/components/CompetenciesCard.tsx`](diffhunk://#diff-09bf4d235d3ecb8d20afc55103b1fea75f22efbd990eb1e44afce548576ae2f1L22-R22): Added an absolute positioned `div` at the bottom to contain the "view" button and adjusted the padding. [[1]](diffhunk://#diff-09bf4d235d3ecb8d20afc55103b1fea75f22efbd990eb1e44afce548576ae2f1L22-R22) [[2]](diffhunk://#diff-09bf4d235d3ecb8d20afc55103b1fea75f22efbd990eb1e44afce548576ae2f1R55-R61)

### Preventing pagination in dropdowns:

* [`src/hooks/use-coaches.ts`](diffhunk://#diff-b5842c261ca2a2beb0a99d0f3c57f2d65390e6d8ad7a266883075e478eb6f7aaL7-R8): Updated the API URL to request 500 coaches per page to avoid pagination.
* [`src/hooks/use-compentencies.ts`](diffhunk://#diff-21eca9f36c4b0313e405d20796a426a46bc0de732b5601fffea12544baa553f9L6-R7): Updated the API URL to request 500 competencies per page to avoid pagination.
* [`src/hooks/use-group-skills.ts`](diffhunk://#diff-0f1c5baf7c6aae69407e2e303685748962d756ee9a91815ed6e5ec6988dd5857L6-R7): Updated the API URL to request 500 skills per page to avoid pagination when fetching group skills.
* [`src/hooks/use-skills.ts`](diffhunk://#diff-cec73491d1040f56fa657ba8a942ec4a83cf75461c4b60911036a87c26846e42L6-R7): Updated the API URL to request 500 skills per page to avoid pagination.
* [`src/hooks/use-students.ts`](diffhunk://#diff-49b12c4c6eb4862f8966053f8e0a10367efb6f709088b9f2e8d52b22dffdbec9L7-R8): Updated the API URL to request 500 students per page to avoid pagination.

### Other changes:

* [`src/lib/queries/server/queries.ts`](diffhunk://#diff-60589cdf987fe6b64a70be4809367c1909bf8aacb1b8cd2b003170accdfe55e2L11-R11): Removed unnecessary query parameters from the `getStudentSkill` function's API call.